### PR TITLE
feat(*): remove unnecessary imports

### DIFF
--- a/build_runner/lib/src/import_optimizer/import_optimizer.dart
+++ b/build_runner/lib/src/import_optimizer/import_optimizer.dart
@@ -152,7 +152,7 @@ class ImportOptimizer{
     }
     // Remove library if another library exports all entities from this library which we use
     var unnecessaryDependentLibraries = new Set<LibraryElement>();
-    if (!settings.allowEunnecessaryDependenciesImports) {
+    if (!settings.allowUnnecessaryDependenciesImports) {
       for (var library in libraries.keys) {
         var elementsImportedFromLibrary = libraries[library];
         for (var anotherLibrary in libraries.keys) {

--- a/build_runner/lib/src/import_optimizer/import_optimizer.dart
+++ b/build_runner/lib/src/import_optimizer/import_optimizer.dart
@@ -32,7 +32,7 @@ class ImportOptimizer{
 
   optimizePackage(String package) async {
     _log.info("Optimization package: '$package'");
-    var assets = (await io.reader.findAssets(new Glob('lib/component/calendar/calendar_abstract.dart'), package: package).toList()).map((item)=>item.toString())
+    var assets = (await io.reader.findAssets(new Glob('lib/**.dart'), package: package).toList()).map((item)=>item.toString())
         .toList();
     optimizeFiles(assets);
   }

--- a/build_runner/lib/src/import_optimizer/import_optimizer.dart
+++ b/build_runner/lib/src/import_optimizer/import_optimizer.dart
@@ -143,7 +143,7 @@ class ImportOptimizer{
         }
       }
       if (libraries.containsKey(optLibrary)) {
-          libraries[optLibrary].add(optLibrary);
+          libraries[optLibrary].add(element);
       } else {
         var elementsImportedFromLibrary = new List<Element>();
         elementsImportedFromLibrary.add(element);
@@ -538,8 +538,8 @@ class UsedImportedElementsVisitor extends RecursiveAstVisitor {
    * Visit identifiers used by the given [directive].
    */
   void _visitDirective(Directive directive) {
-    directive.documentationComment?.accept(this);
-    directive.metadata.accept(this);
+       directive.documentationComment?.accept(this);
+       directive.metadata.accept(this);
   }
 
   void _visitIdentifier(SimpleIdentifier identifier, Element element) {

--- a/build_runner/lib/src/import_optimizer/settings.dart
+++ b/build_runner/lib/src/import_optimizer/settings.dart
@@ -3,6 +3,7 @@ class ImportOptimizerSettings{
   final bool showImportNodes;
   final bool allowSrcImport;
   final int  limitExportsPerFile;
+  final bool allowEunnecessaryDependenciesImports;
 
-  ImportOptimizerSettings({this.applyImports = false, this.showImportNodes = false, this.allowSrcImport = false, this.limitExportsPerFile = 0});
+  ImportOptimizerSettings({this.applyImports = false, this.showImportNodes = false, this.allowSrcImport = false, this.limitExportsPerFile = 0, this.allowEunnecessaryDependenciesImports = false });
 }

--- a/build_runner/lib/src/import_optimizer/settings.dart
+++ b/build_runner/lib/src/import_optimizer/settings.dart
@@ -3,7 +3,7 @@ class ImportOptimizerSettings{
   final bool showImportNodes;
   final bool allowSrcImport;
   final int  limitExportsPerFile;
-  final bool allowEunnecessaryDependenciesImports;
+  final bool allowUnnecessaryDependenciesImports;
 
-  ImportOptimizerSettings({this.applyImports = false, this.showImportNodes = false, this.allowSrcImport = false, this.limitExportsPerFile = 0, this.allowEunnecessaryDependenciesImports = false });
+  ImportOptimizerSettings({this.applyImports = false, this.showImportNodes = false, this.allowSrcImport = false, this.limitExportsPerFile = 0, this.allowUnnecessaryDependenciesImports = false });
 }


### PR DESCRIPTION
If library requires
angular.dart
and di.dart
we don't need import
di.dart, cause it's not optimize performance as Nikolay Samokhin said.

this improvment excludes unnecessary imports